### PR TITLE
makefile: fix linking with static & clenaup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,14 @@ OBJS = font.o config.o input.o video.o menu.o mx.o main.o
 
 VPATH = ./
 
-CFLAGS = -I. -O2 `sdl-config --cflags`
+CFLAGS = -I. -O2 $(shell pkg-config --cflags sdl)
 
-LDFLAGS = `sdl-config --libs` -lSDL_ttf -lSDL_image -lstdc++
+LDFLAGS = $(shell pkg-config --libs sdl SDL_ttf SDL_image) -lstdc++
 
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-	$(CC) $(LDFLAGS) $(OBJS) -o $@
+	$(CC) $(OBJS) -o $@ $(LDFLAGS)
 	@echo Done!!!
 
 %.o: %.cpp

--- a/makefile.miyoo
+++ b/makefile.miyoo
@@ -8,14 +8,14 @@ OBJS = font.o config.o input.o video.o menu.o mx.o main.o
 
 VPATH = ./
 
-CFLAGS = -I. -O2 `sdl-config --cflags` -march=armv5te -mtune=arm926ej-s -DMIYOO
+CFLAGS = -I. -O2 $(shell pkg-config --cflags sdl) -march=armv5te -mtune=arm926ej-s -DMIYOO
 
-LDFLAGS = `sdl-config --libs` -lSDL_ttf -lSDL_image -march=armv5te -mtune=arm926ej-s -lstdc++
+LDFLAGS = $(shell pkg-config --libs sdl SDL_ttf SDL_image) -lstdc++
 
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-	$(CC) $(LDFLAGS) $(OBJS) -o $@
+	$(CC)  $(OBJS) -o $@ $(LDFLAGS)
 	@echo Done!!!
 
 %.o: %.cpp


### PR DESCRIPTION
use pkg-config, also ldflags should come at the end

for cross-compiling without docker you would need to call SYSROOT for proper pkg-config path search, but since you recommend to use docker then not changing for now.