### PR TITLE
remove extra static local var. from update_text_pos()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ VPATH = ./
 
 CFLAGS = -I. -O2 $(shell pkg-config --cflags sdl)
 
-LDFLAGS = $(shell pkg-config --libs sdl SDL_ttf SDL_image) -lstdc++
+LDFLAGS = $(shell pkg-config --libs sdl SDL_ttf SDL_image)
 
 all: $(TARGET)
 

--- a/makefile.miyoo
+++ b/makefile.miyoo
@@ -10,7 +10,7 @@ VPATH = ./
 
 CFLAGS = -I. -O2 $(shell pkg-config --cflags sdl) -march=armv5te -mtune=arm926ej-s -DMIYOO
 
-LDFLAGS = $(shell pkg-config --libs sdl SDL_ttf SDL_image) -lstdc++
+LDFLAGS = $(shell pkg-config --libs sdl SDL_ttf SDL_image)
 
 all: $(TARGET)
 

--- a/mx.cpp
+++ b/mx.cpp
@@ -778,9 +778,9 @@ void set_volume_value(u8 val) {
 
 s16 update_text_pos(char *filename, u16 index) {
     static s16 pos_x = 35;
-    static u16 old_index = index;
+    u16 old_index = index;
 #ifndef MIYOO
-    static u8 frame = 0;
+    u8 frame = 0;
 #endif
     // reset when index change
     if( old_index != index) {


### PR DESCRIPTION
fixes thread-safe initialization of local static for staticly linked libc++ (also you don't need libstdc++ now)

this was troublesome when using staticly linked libpthread in uClibc & could be overcome also by specifying `-fno-threadsafe-statics`